### PR TITLE
Added detectCores for R package installation.

### DIFF
--- a/src/r_installs.R
+++ b/src/r_installs.R
@@ -1,4 +1,4 @@
-options(Ncpus = 6)
+options(Ncpus = parallel::detectCores() - 2)
 install.packages(c(
     "arrow",
     "BH",


### PR DESCRIPTION
Sets Ncpus to detected number of cores minus 2, instead of fixed value.